### PR TITLE
RF: change fetch-zotero.sh mix into a python script fetch-zotero with tests included

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on:
+          - macos-latest
+          - windows-latest
+          - ubuntu-latest
+        python-version:
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade --upgrade-strategy=eager tox tox-gh-actions
+
+      - name: Run tests
+        run: tox
+
+# vim:set et sts=2:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Finally, you can generate a bibliography of only the works that have been cited 
 
 `{{<bibliography cited="true">}}`
 
-#### fetch-zotero.sh
+#### fetch-zotero
 
 fetch-zotero is a script that comes with hugo-bibliography. It allows you to fetch bibliography data from a Zotero group prior to your hugo build. This ensures your bibliography data stays up to date with activity in your zotero group.
 
@@ -79,9 +79,13 @@ Then add the theme in your hugo.toml file.
 
 Hugo-Bibliography comes with shell scripts to fetch bibliography data from common sources, namely Zotero. 
 
-To use the fetch-zotero.sh script in your hugo project, configure your Zotero Group ID using the `ZOTERO_GROUP_ID` environment variable:
+To use the fetch-zotero script in your hugo project, just provide it with the zotero group:
 
-`ZOTERO_GROUP_ID="your-group-id" ./themes/hugo-bibliography/fetch-zotero.sh`
+./themes/hugo-bibliography/fetch-zotero -g YOUR-GROUP-ID
+
+or provide it via  `ZOTERO_GROUP_ID` environment variable:
+
+ZOTERO_GROUP_ID="YOUR-GROUP-ID" ./themes/hugo-bibliography/fetch-zotero
 
 Next, configure the script based on the following use cases.
 
@@ -95,7 +99,7 @@ To use the fetch-zotero script when running the application locally, first make 
 
 If you have both of these dependencies installed, run the following to start hugo locally. The fetch script will run first and the hugo-build will include the appropriate data file.
 
-`ZOTERO_GROUP_ID="your-group-id" ./themes/hugo-bibliography/fetch-zotero.sh && hugo server`
+`ZOTERO_GROUP_ID="your-group-id" ./themes/hugo-bibliography/fetch-zotero && hugo server`
 
 ### Running Hugo Locally through Docker:
 
@@ -106,7 +110,7 @@ If you're using a docker-compose file, the command should look like the followin
 `command: >
       sh -c "
         apk add --no-cache curl jq &&
-        ZOTERO_GROUP_ID=\"your-group-id\" ./themes/hugo-bibliography/fetch-zotero.sh &&
+        ZOTERO_GROUP_ID=\"your-group-id\" ./themes/hugo-bibliography/fetch-zotero &&
         hugo server --bind 0.0.0.0 --port 1313
       "
 `
@@ -117,7 +121,7 @@ If you're deploying your Hugo Site through Github Pages, add in the following co
 `- name: Install jq for fetch script
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Run Zotero fetch script
-        run: ZOTERO_GROUP_ID="your-group-id" ../../themes/hugo-bibliography/fetch-zotero.sh
+        run: ZOTERO_GROUP_ID="your-group-id" ../../themes/hugo-bibliography/fetch-zotero
 `
 
 ## Customization

--- a/fetch-zotero
+++ b/fetch-zotero
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Fetch bibliography and collections data from Zotero API."""
+
+import argparse
+import json
+import logging
+import os
+import sys
+import urllib.request
+import urllib.parse
+from pathlib import Path
+from typing import Dict, List, Any, Optional
+
+
+def get_total_results(url: str) -> int:
+    """Get the total number of results from Zotero API headers."""
+    req = urllib.request.Request(url, method='HEAD')
+    with urllib.request.urlopen(req) as response:
+        total_results = response.headers.get('Total-Results')
+        if total_results:
+            return int(total_results)
+    return 0
+
+
+def fetch_zotero_data(group_id: str, endpoint: str, limit: int = 25) -> List[Dict[str, Any]]:
+    """Fetch all data from a Zotero API endpoint with pagination."""
+    base_url = f"https://api.zotero.org/groups/{group_id}/{endpoint}"
+    logger = logging.getLogger(__name__)
+
+    # Get total number of results
+    total_results = get_total_results(f"{base_url}?limit=1")
+
+    all_data = []
+    start_index = 0
+
+    while start_index < total_results:
+        # Build URL with proper query parameters
+        params = urllib.parse.urlencode({
+            'start': start_index,
+            'limit': limit,
+            'format': 'json'
+        })
+        url = f"{base_url}?{params}"
+
+        with urllib.request.urlopen(url) as response:
+            items = json.loads(response.read())
+            # Extract the .data field from each item
+            all_data.extend([item['data'] for item in items if 'data' in item])
+
+        start_index += limit
+
+    return all_data
+
+
+def build_collection_tree(flat_collections: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Build a hierarchical tree structure from flat collections."""
+    collection_map = {
+        collection["key"]: {**collection, "children": []}
+        for collection in flat_collections
+    }
+    roots = []
+
+    for collection in flat_collections:
+        if collection.get("parentCollection"):
+            parent = collection_map.get(collection["parentCollection"])
+            if parent:
+                parent["children"].append(collection_map[collection["key"]])
+        else:
+            roots.append(collection_map[collection["key"]])
+
+    return roots
+
+
+def fetch_zotero(group_id: str, output_dir: str = "data") -> None:
+    """
+    Fetch bibliography and collections from Zotero API.
+    
+    Args:
+        group_id: Zotero group ID
+        output_dir: Directory to save the output files
+    """
+    logger = logging.getLogger(__name__)
+
+    # Create output directory if it doesn't exist
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    bib_file = Path(output_dir) / "bibliography.json"
+    collection_flat_file = Path(output_dir) / "collections-flat.json"
+    collection_file = Path(output_dir) / "collections.json"
+
+    logger.info(f"Fetching data from Zotero group {group_id}...")
+
+    # Fetch bibliography items
+    logger.info("Fetching bibliography items...")
+    bibliography = fetch_zotero_data(group_id, "items")
+    with open(bib_file, 'w', encoding='utf-8') as f:
+        json.dump(bibliography, f, indent=2, ensure_ascii=False)
+    logger.info(f"Saved {len(bibliography)} bibliography items to {bib_file}")
+
+    # Fetch collections
+    logger.info("Fetching collections...")
+    collections_flat = fetch_zotero_data(group_id, "collections")
+    with open(collection_flat_file, 'w', encoding='utf-8') as f:
+        json.dump(collections_flat, f, indent=2, ensure_ascii=False)
+    logger.info(f"Saved {len(collections_flat)} collections to {collection_flat_file}")
+
+    # Build collection tree
+    logger.info("Building collection tree...")
+    collection_tree = build_collection_tree(collections_flat)
+    with open(collection_file, 'w', encoding='utf-8') as f:
+        json.dump(collection_tree, f, indent=2, ensure_ascii=False)
+    logger.info(f"Saved collection tree to {collection_file}")
+
+
+def main():
+    """Command-line interface for fetch_zotero."""
+    parser = argparse.ArgumentParser(
+        description='Fetch bibliography and collections from Zotero API'
+    )
+    parser.add_argument(
+        '-g', '--group-id',
+        help='Zotero group ID',
+        default=os.environ.get('ZOTERO_GROUP_ID', '5010351')
+    )
+    parser.add_argument(
+        '-o', '--output-dir',
+        help='Directory to save output files (default: data)',
+        default='data'
+    )
+
+    args = parser.parse_args()
+
+    # Set up logging
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(message)s'
+    )
+
+    try:
+        fetch_zotero(
+            group_id=args.group_id,
+            output_dir=args.output_dir
+        )
+    except Exception as e:
+        logging.error(f"Error: {e}")
+        sys.exit(1)
+
+
+#
+# Some rudimentary tests
+#
+
+import unittest
+import tempfile
+import shutil
+from unittest.mock import patch, MagicMock
+
+
+class TestFetchZotero(unittest.TestCase):
+    """Tests for fetch_zotero functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_build_collection_tree(self):
+        """Test building hierarchical collection tree from flat structure."""
+        flat_collections = [
+            {"key": "parent1", "name": "Parent 1", "parentCollection": False},
+            {"key": "child1", "name": "Child 1", "parentCollection": "parent1"},
+            {"key": "child2", "name": "Child 2", "parentCollection": "parent1"},
+            {"key": "parent2", "name": "Parent 2", "parentCollection": False},
+        ]
+
+        tree = build_collection_tree(flat_collections)
+
+        self.assertEqual(len(tree), 2)  # Two root collections
+        self.assertEqual(tree[0]["key"], "parent1")
+        self.assertEqual(len(tree[0]["children"]), 2)  # Parent1 has 2 children
+        self.assertEqual(tree[1]["key"], "parent2")
+        self.assertEqual(len(tree[1]["children"]), 0)  # Parent2 has no children
+
+    @patch('urllib.request.urlopen')
+    def test_fetch_zotero_data_with_pagination_and_unicode(self, mock_urlopen):
+        """Test fetching data with pagination and Unicode characters."""
+        # Mock responses for HEAD request (total count)
+        head_response = MagicMock()
+        head_response.headers = {'Total-Results': '3'}
+        head_response.__enter__ = lambda self: head_response
+        head_response.__exit__ = lambda self, *args: None
+
+        # Mock responses for data requests with Unicode characters
+        data_response = MagicMock()
+        data_response.read.return_value = json.dumps([
+            {"data": {"key": "item1", "title": "Trusting Others to 'Do the Math'"}},
+            {"data": {"key": "item2", "title": "Leptazolines A\u2013D, \u201cWilloughby\u2013Hoye\u201d Scripts"}},
+            {"data": {"key": "item3", "title": "Français résumé\u2014with em-dash", "note": "日本語"}},
+        ]).encode('utf-8')
+        data_response.__enter__ = lambda self: data_response
+        data_response.__exit__ = lambda self, *args: None
+
+        mock_urlopen.side_effect = [head_response, data_response]
+
+        result = fetch_zotero_data("12345", "items", limit=25)
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0]["title"], "Trusting Others to 'Do the Math'")
+        self.assertIn("\u2013", result[1]["title"])  # en-dash
+        self.assertIn("\u201c", result[1]["title"])  # curly quotes
+        self.assertIn("\u2014", result[2]["title"])  # em-dash
+        self.assertEqual(result[2]["note"], "日本語")
+
+    @patch('__main__.fetch_zotero_data')
+    def test_fetch_zotero_creates_files_with_unicode(self, mock_fetch):
+        """Test that fetch_zotero creates files and handles Unicode correctly."""
+        # Mock data with Unicode characters
+        mock_items = [
+            {"key": "ITEM1", "title": "Trusting Others to 'Do the Math'", "itemType": "journalArticle"},
+            {"key": "ITEM2", "title": "Leptazolines A\u2013D", "note": "Contains \u201cquotes\u201d", "itemType": "book"}
+        ]
+        mock_collections = [
+            {"key": "COLL1", "name": "Test Collection\u2014with em-dash", "parentCollection": False}
+        ]
+
+        mock_fetch.side_effect = [mock_items, mock_collections]
+
+        # Run fetch_zotero
+        fetch_zotero("12345", self.test_dir)
+
+        # Check files were created
+        bib_file = Path(self.test_dir) / "bibliography.json"
+        collections_flat_file = Path(self.test_dir) / "collections-flat.json"
+        collections_file = Path(self.test_dir) / "collections.json"
+
+        self.assertTrue(bib_file.exists())
+        self.assertTrue(collections_flat_file.exists())
+        self.assertTrue(collections_file.exists())
+
+        # Check content and Unicode preservation
+        with open(bib_file, 'r', encoding='utf-8') as f:
+            bibliography = json.load(f)
+            self.assertEqual(len(bibliography), 2)
+            self.assertEqual(bibliography[0]["key"], "ITEM1")
+            self.assertEqual(bibliography[0]["title"], "Trusting Others to 'Do the Math'")
+            self.assertIn("\u2013", bibliography[1]["title"])  # en-dash preserved
+            self.assertIn("\u201c", bibliography[1]["note"])  # curly quotes preserved
+
+        with open(collections_flat_file, 'r', encoding='utf-8') as f:
+            collections = json.load(f)
+            self.assertEqual(len(collections), 1)
+            self.assertEqual(collections[0]["name"], "Test Collection\u2014with em-dash")
+            self.assertIn("\u2014", collections[0]["name"])  # em-dash preserved
+
+        with open(collections_file, 'r', encoding='utf-8') as f:
+            collection_tree = json.load(f)
+            self.assertEqual(len(collection_tree), 1)
+            self.assertIn("children", collection_tree[0])
+            self.assertIn("\u2014", collection_tree[0]["name"])  # em-dash preserved in tree
+
+
+def run_tests():
+    """Run the test suite."""
+    unittest.main(argv=[''], exit=False, verbosity=2)
+
+
+if __name__ == '__main__':
+    # Check if we're running tests
+    if len(sys.argv) > 1 and sys.argv[1] == 'test':
+        run_tests()
+    else:
+        main()

--- a/fetch-zotero.sh
+++ b/fetch-zotero.sh
@@ -1,66 +1,7 @@
 #!/bin/sh
 
-BIB_FILE="data/bibliography.json"
-COLLECTION_FILE="data/collections-flat.json"
-GROUP_ID="${ZOTERO_GROUP_ID:-5010351}"
-LIMIT=25
-START_INDEX=0
+set -eu
 
-mkdir -p data
-
-echo "[]" > "$BIB_FILE"
-echo "[]" > "$COLLECTION_FILE"
-
-TOTAL_RESULTS=$(curl -s -I "https://api.zotero.org/groups/$GROUP_ID/items?limit=1" \
-  | grep -i "Total-Results:" | awk '{print $2}' | tr -d '\r')
-
-while [ "$START_INDEX" -lt "$TOTAL_RESULTS" ]; do
-
-  curl -s "https://api.zotero.org/groups/$GROUP_ID/items?start="$START_INDEX"?limit=$LIMIT?format=json" \
-  | jq '[.[] | .data]' > "tmp_items.json"
-
-  jq -s '.[0] + .[1]' "$BIB_FILE" tmp_items.json > tmp_merged.json
-  mv tmp_merged.json "$BIB_FILE"
-
-  START_INDEX=$((START_INDEX + LIMIT))
-done
-
-rm -f tmp_items.json
-
-START_INDEX=0
-TOTAL_RESULTS=$(curl -s -I "https://api.zotero.org/groups/$GROUP_ID/collections?limit=1" \
-  | grep -i "Total-Results:" | awk '{print $2}' | tr -d '\r')
-
-while [ "$START_INDEX" -lt "$TOTAL_RESULTS" ]; do
-
-  curl -s "https://api.zotero.org/groups/$GROUP_ID/collections?start="$START_INDEX"?limit=$LIMIT?format=json" \
-  | jq '[.[] | .data]' > "tmp_collections.json"
-
-  jq -s '.[0] + .[1]' "$COLLECTION_FILE" tmp_collections.json > tmp_merged.json
-  mv tmp_merged.json "$COLLECTION_FILE"
-  
-  START_INDEX=$((START_INDEX + LIMIT))
-done
-
-rm -f tmp_collections.json
-
-python3 <<EOF
-import json
-
-with open("data/collections-flat.json") as f:
-    collections = json.load(f)
-
-collection_map = {collection["key"]: {**collection, "children": []} for collection in collections}
-roots = []
-
-for collection in collections:
-    if collection.get("parentCollection"):
-        parent = collection_map.get(collection["parentCollection"])
-        if parent:
-            parent["children"].append(collection_map[collection["key"]])
-    else:
-        roots.append(collection_map[collection["key"]])
-
-with open("data/collections.json", "w") as f:
-    json.dump(roots, f, indent=2)
-EOF
+thescript="${0%.sh}"
+echo "DEPRECATED: .sh script is deprecated, just call '$thescript' directly"
+"$thescript" "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+envlist = py{39,310,311,312,313}
+skip_missing_interpreters = true
+
+[testenv]
+deps =
+    # No external dependencies needed for tests since we use unittest and mock
+commands =
+    python fetch-zotero test
+
+[testenv:lint]
+deps =
+    flake8
+commands =
+    flake8 fetch-zotero
+
+[testenv:type]
+deps = 
+    mypy
+commands =
+    mypy fetch-zotero
+
+[gh-actions]
+python =
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313


### PR DESCRIPTION
No tests for actual interaction with zotero API, but could be added. Produced files should be identical (besides may be trailing new line) to original one. I have "kept" fetch-zotero.sh wrapper to ease transition. `tox` is a convenience to sweep tests locally across python versions.  Conversion primarily was done using `claude` code.

edit: feel free to tune to your liking, should be able to push to my branch AFAIK