### PR TITLE
Add go module configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dh-tech/hugo-bibliography
+
+go 1.23.4


### PR DESCRIPTION
This adds a go module so this theme can (I hope) be installed as a module.  First step towards addressing #43 

I created it by running:
```sh
hugo mod init github.com/dh-tech/hugo-bibliography
```

I think that once it is pushed to github on the main branch, it can be installed as a go module.