### PR TITLE
Add optional partials to create citation index/map by key.

### DIFF
--- a/layouts/partials/zotero/build-citations.html
+++ b/layouts/partials/zotero/build-citations.html
@@ -1,3 +1,12 @@
+{{/*
+  Adds list of authors as string.
+  
+  Returns a slice of maps with "authorStr": list of authors as string,
+  "key": Zotero item key, "citation": Zotero item map.
+  
+  @param {slice} items The Zotero bibliography items (.data member only).
+  @param {int} authorNum The number of authors in the author string.
+*/}}
 {{- $items := .items -}}
 {{- $authorNum := .authorNum -}}
 {{- $citations := slice -}}
@@ -19,6 +28,7 @@
 
   {{- $citations = $citations | append (dict
       "authorStr" $authorStr
+      "key" .key
       "citation" .
   ) -}}
 {{- end }}

--- a/layouts/partials/zotero/fetch-items.html
+++ b/layouts/partials/zotero/fetch-items.html
@@ -1,3 +1,10 @@
+{{/*
+  Downloads the raw Zotero bibliography items in a group.
+  
+  Returns a slice of maps.
+  
+  @params {string} groupId The Zotero group id.
+*/}}
 {{- $groupId := .groupId -}}
 {{- $limit := 100 -}}
 {{- $scratch := newScratch -}}

--- a/layouts/partials/zotero/filter-items.html
+++ b/layouts/partials/zotero/filter-items.html
@@ -1,3 +1,13 @@
+{{/*
+  Filter bibliography items based on fields or citations. 
+
+  Returns slice of items (only .data member).
+  
+  @params {slice} items The raw Zotero bibliography items.
+  @params {map} params The field names and values to match.
+  @params {boolean} onlyCited If only cited items should be returned.
+  @params {slice} citedTitles The list of cited titles.
+*/}}
 {{- $items := .items -}}
 {{- $params := .params -}}
 {{- $onlyCited := .onlyCited -}}

--- a/layouts/partials/zotero/index-citations-key.html
+++ b/layouts/partials/zotero/index-citations-key.html
@@ -1,0 +1,14 @@
+{{/*
+  Returns a map with citations indexed by key.
+  
+  @param {slice} The slice of citations.
+*/}}
+{{ $citations := . }}
+{{ $index := newScratch }}
+
+{{ range $citations }}
+  {{ $key := .key }}
+  {{ $index.Set $key . }}
+{{ end }}
+
+{{ return $index }}

--- a/layouts/partials/zotero/unpack-items.html
+++ b/layouts/partials/zotero/unpack-items.html
@@ -1,0 +1,13 @@
+{{/* 
+  Unpack raw Zotero bibliography items, compatible with filter-items.
+  
+  Returns slice of bibliography items (.data member only).
+  
+  @param {slice} The raw bibliography items.
+*/}}
+{{ $items := . }}
+{{ $unpacked := slice }} 
+{{ range $items }}
+  {{ $unpacked = $unpacked | append .data }}
+{{ end }}
+{{ return $unpacked }}


### PR DESCRIPTION
This PR adds partial `index-citations-key` that accepts a slice of citations returned from `build-citations` and returns a map indexed by Zotero-id. (I use this to process Zotero relations containing ids and create links with author and title information.) 

The PR also adds more code comments and `unpack-items` partial that can be used instead of `filter-items`.