### PR TITLE
Fix issues with citations rendering properly

### DIFF
--- a/layouts/shortcodes/bibliography.html
+++ b/layouts/shortcodes/bibliography.html
@@ -4,6 +4,7 @@
         margin-bottom: 1rem;
         text-indent: -2rem;
         padding-left: 2rem;
+        list-style-type: none;
     }
 </style>
 
@@ -39,7 +40,7 @@
 {{ $collections := partial "zotero/build-collection-tree.html" site.Params.groupId }}
 
 {{if $onlyCited }}
-<ul style="list-style-type: none;" class="apa-citation-list">
+<ul class="apa-citation-list">
   {{ range $index, $citation := $citations }}
     <div id="ref-{{ $index }}">
     {{ partial "render/render-citation.html" $citation }}
@@ -47,7 +48,7 @@
   {{ end }}
 </ul>
 {{else}}
-<ul style="list-style-type: none;" class="apa-citation-list">
+<ul class="apa-citation-list">
   {{ range $citations }}
     {{ partial "render/render-citation.html" . }}
   {{ end }}

--- a/layouts/shortcodes/bibliography.html
+++ b/layouts/shortcodes/bibliography.html
@@ -39,7 +39,7 @@
 {{ $collections := partial "zotero/build-collection-tree.html" site.Params.groupId }}
 
 {{if $onlyCited }}
-<ul class="apa-citation-list">
+<ul style="list-style-type: none;" class="apa-citation-list">
   {{ range $index, $citation := $citations }}
     <div id="ref-{{ $index }}">
     {{ partial "render/render-citation.html" $citation }}
@@ -47,7 +47,7 @@
   {{ end }}
 </ul>
 {{else}}
-<ul class="apa-citation-list">
+<ul style="list-style-type: none;" class="apa-citation-list">
   {{ range $citations }}
     {{ partial "render/render-citation.html" . }}
   {{ end }}

--- a/layouts/shortcodes/cite.html
+++ b/layouts/shortcodes/cite.html
@@ -30,9 +30,9 @@
     {{- $authors := slice -}}
     {{- range $entry.creators }}
 
-    {{- if eq $entry.creatorType "author" }}
-    {{- if $entry.lastName }}
-    {{- $name := printf "%s" $entry.lastName}}
+    {{- if eq .creatorType "author" }}
+    {{- if .lastName }}
+    {{- $name := printf "%s" .lastName}}
     {{- $authors = $authors | append $name }}
     {{- end }}
     {{- end }}

--- a/layouts/shortcodes/works-cited.html
+++ b/layouts/shortcodes/works-cited.html
@@ -3,6 +3,7 @@
         margin-bottom: 1rem;
         text-indent: -2rem;
         padding-left: 2rem;
+        list-style-type: none;
     }
 </style>
 
@@ -49,7 +50,7 @@
 
 {{ $collections := partial "zotero/build-collection-tree.html" site.Params.groupId }}
 
-<ul style="list-style-type: none;" class="apa-citation-list">
+<ul class="apa-citation-list">
   {{- range $citation := $citations }}
     {{- $cols := $citation.citation.collections | default (slice) }}
     {{- if eq (len $cols) 0 }}

--- a/layouts/shortcodes/works-cited.html
+++ b/layouts/shortcodes/works-cited.html
@@ -10,7 +10,7 @@
 {{- $citations := slice -}}
 
 {{- $context := . }}
-{{- $onlyCited := and $context.IsNamedParams (eq ($context.Get "cited") "true") }}
+{{- $onlyCited := true }}
 
 {{- $citedTitles := slice -}}
 {{- if $onlyCited }}


### PR DESCRIPTION
This pull request fixes two bugs:

1. For the shortcode to render a works cited page, the condition that was checked could never evaluate to true. It expected a named parameter "cited" that was not part of the documentation for the usage of the shortcode. This PR sets the condition to true so that the works cited page renders correctly.
2. In the cite shortcode, the incorrect context was being passed when rendering the author string. This meant the author string was always empty and therefore could never be rendered. This change passes the correct context, thereby rendering the author's name.

Additionally, this adds styling to the bibliography shortcode so it does not render with bullets.